### PR TITLE
Add canvas dependency and update chartjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Then you just need to define the plugin options in your chart definition object.
 - [chartjs-plugin-datalabels documentation](https://chartjs-plugin-datalabels.netlify.app/guide/)
 - [chartjs-plugin-annotations](https://github.com/chartjs/chartjs-plugin-annotation#readme)
 
+#### Verify Canvas on Node.js 20
+After installing dependencies, run:
+
+```
+node test/test-canvas.js
+```
+to check that the `canvas` library works.
+
 #### Please report bugs, suggest improvements!
 https://github.com/gemini86/node-red-contrib-chart-image/issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "node-red-contrib-chart-image",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-chart-image",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "chart.js": "^2.7.3",
-        "chartjs-node-canvas": "^3.2.0",
-        "chartjs-plugin-annotation": "^0.5.7",
+        "canvas": "^2.11.2",
+        "chart.js": "^3.9.1",
+        "chartjs-node-canvas": "^4.1.6",
+        "chartjs-plugin-annotation": "^1.4.0",
         "chartjs-plugin-annotations": "^0.6.1",
-        "chartjs-plugin-datalabels": "^0.7.0"
+        "chartjs-plugin-datalabels": "^2.2.0"
       },
       "devDependencies": {
         "eslint": "^6.8.0",
@@ -234,10 +235,11 @@
       }
     },
     "node_modules/canvas": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.2.tgz",
-      "integrity": "sha512-FSmlsip0nZ0U4Zcfht0qBJqDhlfGuevTZKE8h+dBOYrJjGvY3iqMGSzzbvkaFhvMXiVxfcMaPHS/kge++T5SKg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.17.0",
@@ -268,18 +270,16 @@
       "dev": true
     },
     "node_modules/chart.js": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
-      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
-      "dependencies": {
-        "chartjs-color": "^2.1.0",
-        "moment": "^2.10.2"
-      }
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz",
+      "integrity": "sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==",
+      "license": "MIT"
     },
     "node_modules/chartjs-color": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
       "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "license": "MIT",
       "dependencies": {
         "chartjs-color-string": "^0.6.0",
         "color-convert": "^1.9.3"
@@ -289,28 +289,37 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
       "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0"
       }
     },
     "node_modules/chartjs-node-canvas": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/chartjs-node-canvas/-/chartjs-node-canvas-3.2.0.tgz",
-      "integrity": "sha512-MT0K28VG8BXwCdh5BdRXNw4nzJWKzcN3t/xgTr8zJ8M6uOXl7hRdtIW8rEUcylkLED8LGsnJmSkcnqlhPy841g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/chartjs-node-canvas/-/chartjs-node-canvas-4.1.6.tgz",
+      "integrity": "sha512-UQJbPWrvqB/FoLclGA9BaLQmZbzSYlujF4w8NZd6Xzb+sqgACBb2owDX6m7ifCXLjUW5Nz0Qx0qqrTtQkkSoYw==",
+      "license": "MIT",
       "dependencies": {
-        "canvas": "^2.6.1",
-        "tslib": "^1.14.1"
+        "canvas": "^2.8.0",
+        "tslib": "^2.3.1"
       },
       "peerDependencies": {
-        "chart.js": "^2.7.3"
+        "chart.js": "^3.5.1"
       }
     },
+    "node_modules/chartjs-node-canvas/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/chartjs-plugin-annotation": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-0.5.7.tgz",
-      "integrity": "sha512-tKN5KLc69unyZGTvSdhVQEyAOhVNnSkFCCgefZhO4UaqFfABZGFU/d9p6WM2KB0eXFs/rR3Jayh7dvyASC7K0A==",
-      "dependencies": {
-        "chart.js": "^2.4.0"
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-1.4.0.tgz",
+      "integrity": "sha512-OC0eGoVvdxTtGGi8mV3Dr+G1YmMhtYYQWqGMb2uWcgcnyiBslaRKPofKwAYWPbh7ABnmQNsNDQLIKPH+XiaZLA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^3.1.0"
       }
     },
     "node_modules/chartjs-plugin-annotations": {
@@ -321,12 +330,23 @@
         "chart.js": "^2.4.0"
       }
     },
+    "node_modules/chartjs-plugin-annotations/node_modules/chart.js": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
     "node_modules/chartjs-plugin-datalabels": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-0.7.0.tgz",
-      "integrity": "sha512-PKVUX14nYhH0wcdCpgOoC39Gbzvn6cZ7O9n+bwc02yKD9FTnJ7/TSrBcfebmolFZp1Rcicr9xbT0a5HUbigS7g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
       "peerDependencies": {
-        "chart.js": ">= 2.7.0 < 3"
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/chownr": {
@@ -1356,9 +1376,10 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -1934,7 +1955,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -2206,9 +2228,9 @@
       "dev": true
     },
     "canvas": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.2.tgz",
-      "integrity": "sha512-FSmlsip0nZ0U4Zcfht0qBJqDhlfGuevTZKE8h+dBOYrJjGvY3iqMGSzzbvkaFhvMXiVxfcMaPHS/kge++T5SKg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.17.0",
@@ -2233,13 +2255,9 @@
       "dev": true
     },
     "chart.js": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
-      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
-      "requires": {
-        "chartjs-color": "^2.1.0",
-        "moment": "^2.10.2"
-      }
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz",
+      "integrity": "sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w=="
     },
     "chartjs-color": {
       "version": "2.4.1",
@@ -2259,21 +2277,26 @@
       }
     },
     "chartjs-node-canvas": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/chartjs-node-canvas/-/chartjs-node-canvas-3.2.0.tgz",
-      "integrity": "sha512-MT0K28VG8BXwCdh5BdRXNw4nzJWKzcN3t/xgTr8zJ8M6uOXl7hRdtIW8rEUcylkLED8LGsnJmSkcnqlhPy841g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/chartjs-node-canvas/-/chartjs-node-canvas-4.1.6.tgz",
+      "integrity": "sha512-UQJbPWrvqB/FoLclGA9BaLQmZbzSYlujF4w8NZd6Xzb+sqgACBb2owDX6m7ifCXLjUW5Nz0Qx0qqrTtQkkSoYw==",
       "requires": {
-        "canvas": "^2.6.1",
-        "tslib": "^1.14.1"
+        "canvas": "^2.8.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
       }
     },
     "chartjs-plugin-annotation": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-0.5.7.tgz",
-      "integrity": "sha512-tKN5KLc69unyZGTvSdhVQEyAOhVNnSkFCCgefZhO4UaqFfABZGFU/d9p6WM2KB0eXFs/rR3Jayh7dvyASC7K0A==",
-      "requires": {
-        "chart.js": "^2.4.0"
-      }
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-1.4.0.tgz",
+      "integrity": "sha512-OC0eGoVvdxTtGGi8mV3Dr+G1YmMhtYYQWqGMb2uWcgcnyiBslaRKPofKwAYWPbh7ABnmQNsNDQLIKPH+XiaZLA==",
+      "requires": {}
     },
     "chartjs-plugin-annotations": {
       "version": "0.6.1",
@@ -2281,12 +2304,23 @@
       "integrity": "sha512-QXUbeGtgV8kRG7LPyWBVHTqsmQwknxAqwnM2Gn8AF7Brk5guoHVZWpHzvPAmkcZ9b+vWiWvsLjU6SoF+b6+i5Q==",
       "requires": {
         "chart.js": "^2.4.0"
+      },
+      "dependencies": {
+        "chart.js": {
+          "version": "2.9.4",
+          "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+          "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+          "requires": {
+            "chartjs-color": "^2.1.0",
+            "moment": "^2.10.2"
+          }
+        }
       }
     },
     "chartjs-plugin-datalabels": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-0.7.0.tgz",
-      "integrity": "sha512-PKVUX14nYhH0wcdCpgOoC39Gbzvn6cZ7O9n+bwc02yKD9FTnJ7/TSrBcfebmolFZp1Rcicr9xbT0a5HUbigS7g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
       "requires": {}
     },
     "chownr": {
@@ -3069,9 +3103,9 @@
       }
     },
     "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "ms": {
       "version": "2.1.2",
@@ -3490,7 +3524,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   "author": "gemini86",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "chart.js": "^2.7.3",
-    "chartjs-node-canvas": "^3.2.0",
-    "chartjs-plugin-annotation": "^0.5.7",
+    "chart.js": "^3.9.1",
+    "chartjs-node-canvas": "^4.1.6",
+    "canvas": "^2.11.2",
+    "chartjs-plugin-annotation": "^1.4.0",
     "chartjs-plugin-annotations": "^0.6.1",
-    "chartjs-plugin-datalabels": "^0.7.0"
+    "chartjs-plugin-datalabels": "^2.2.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/test/test-canvas.js
+++ b/test/test-canvas.js
@@ -1,0 +1,12 @@
+const { createCanvas } = require('canvas');
+
+try {
+  const canvas = createCanvas(100, 100);
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = 'red';
+  ctx.fillRect(10, 10, 80, 80);
+  console.log('Canvas loaded and rendered successfully');
+} catch (err) {
+  console.error('Canvas failed:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add canvas and bump chartjs related packages
- include simple canvas test script
- document how to run the canvas test

## Testing
- `npm install`
- `node test/test-canvas.js`


------
https://chatgpt.com/codex/tasks/task_b_6883e238e60883329c8515d2dee00250